### PR TITLE
TEL-1242: add mem and cpu profiling capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ init:   		## Install dependencies
 	go get -u github.com/AlekSi/gocoverutil
 	go get -u golang.org/x/perf/cmd/benchstat
 	go get -u github.com/dvyukov/go-fuzz/...
+	go get -u github.com/pkg/profile
 	go get -u gopkg.in/alecthomas/gometalinter.v2
 	gometalinter.v2 --install
 
@@ -37,6 +38,15 @@ bench: install   	## Install and bench test
 
 run: install 		## Install and run promhouse
 	go run ./cmd/promhouse/*.go --log.level=info
+
+run-memprofile: install ## Run with memory profiling enabled. It will generate a pprof file readable by go tool pprof. NOTE: promhouse binary needs to be in your PATH
+	promhouse --log.level=info --profile.mem
+
+run-cpuprofile: install ## Run with memory profiling enabled. It will generate a pprof file readable by go tool pprof. NOTE: promhouse binary needs to be in your PATH
+	promhouse ./cmd/promhouse/*.go --log.level=info --profile.cpu
+
+valgrind: install       ## Install and run promhouse with valgrind
+	valgrind --tool=memcheck go run ./cmd/promhouse/*.go --log.level=info
 
 run-race: install-race  ## Install and race run
 	go run -race ./cmd/promhouse/*.go --log.level=info

--- a/README.md
+++ b/README.md
@@ -54,6 +54,44 @@ make tests
 make gofuzz
 ```
 
+## Runing memory and cpu profiling
+### Prerequisites
+You will need to install graphviz:
+```bash
+apt-get install graphviz
+```
+Or if you are in mac:
+```bash
+brew install graphviz
+```
+
+### Generate the profiling data
+Run promhouse with either cpu or mem profiling enabled by running it with:
+```bash
+make run-memprofile
+```
+Or
+```bash
+make run-cpuprofile
+```
+Run any tests you want to profile (for example, generating some load), and stop promhouse. You will see where the pprof file is created in an output like this:
+```
+promhouse --log.level=info --profile.mem
+stdlog: profile: memory profiling enabled (rate 4096), /tmp/profile371198043/mem.pprof
+```
+The profiling needs some data. If you do not run it for long enough (allow it at least 30 secs or so), you won't get enough data and the profiling won't work.
+
+NOTE: the promhouse binary needs to be in your path. That would probably look like this:
+```bash
+export PATH="${GOPATH}/bin:$PATH"
+```
+
+### Graph the gathered data
+You can now use [pprof](https://github.com/google/pprof) to read the data. The quickest way I found is to generate a pdf:
+```bash
+go tool pprof --pdf ${GOPATH}/bin/promhouse /tmp/profile382238388/mem.pprof > profilegraph.pdf
+```
+
 ## Database Schema
 
 ```sql

--- a/cmd/promhouse/main.go
+++ b/cmd/promhouse/main.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pkg/profile"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -160,6 +161,8 @@ func main() {
 		maxOpenConnsF = kingpin.Flag("db.max-open-conns", "Maximum number of open connections to the database").Default("75").Int()
 		storageTypeF  = kingpin.Flag("storage-type", "Storage type").Default("clickhouse").String()
 		logLevelF     = kingpin.Flag("log.level", "Log level").Default("warn").String()
+		memProfile    = kingpin.Flag("profile.mem", "Enable memory profiling").Bool()
+		cpuProfile    = kingpin.Flag("profile.cpu", "Enable cpu profiling").Bool()
 	)
 	kingpin.CommandLine.HelpFlag.Short('h')
 	kingpin.Parse()
@@ -169,6 +172,12 @@ func main() {
 		logrus.Fatal(err)
 	}
 	logrus.SetLevel(level)
+	if *cpuProfile {
+	  defer profile.Start().Stop()
+	}
+	if *memProfile {
+	  defer profile.Start(profile.MemProfile).Stop()
+	}
 
 	l := logrus.WithField("component", "main")
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Instrument code so we can use ppfrof to generate memory and cpu
profiles.
Document how to generate and read this profiles
Update Makefile to do so easily
Add valgrind makefile command to run promhouse with vagrind memory leak
detection tool