### PR TITLE
TEL-1242: add utils and docs to run load tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,25 @@ gofuzz: test            ## Go-fuzz
 	go-fuzz-build -func=FuzzJSON -o=json-fuzz.zip github.com/hmrc/Promhouse/storages/clickhouse
 	go-fuzz -bin=json-fuzz.zip -workdir=go-fuzz/json
 
-up:			## Starts the test environment (Linux)
+up-test-env:	        ## Starts the test environment - no promhouse (Linux)
+	cp ${GOPATH}/bin/promhouse misc/promhouse_bin
 	docker-compose -f misc/docker-compose-linux.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
 
-up-mac:                 ## Starts the test environment (Mac)
+up-mac-test-env:        ## Starts the test environment - no promhouse (Mac)
 	docker-compose -f misc/docker-compose-mac.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
+
+up: install		## Starts the test environment - with promhouse (Linux)
+	rm -f misc/promhouse_bin
+	cp ${GOPATH}/bin/promhouse misc/promhouse_bin
+	docker-compose -f misc/docker-compose-linux.yml -f misc/docker-compose-promhouse.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
+
+up-mac: install         ## Starts the test environment - with promhouse (Mac)
+	rm -f misc/promhouse_bin
+	cp ${GOPATH}/bin/promhouse misc/promhouse_bin
+	docker-compose -f misc/docker-compose-mac.yml -f misc/docker-compose-promhouse.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
+
+generate-load:          ## generates metrics in a running test environment with avalanch
+	docker run --net=host quay.io/freshtracks.io/avalanche
 
 down:                   ## Stops the test environment (Linux)
 	docker-compose -f misc/docker-compose-linux.yml -p promhouse down --volumes --remove-orphans

--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ You can now use [pprof](https://github.com/google/pprof) to read the data. The q
 go tool pprof --pdf ${GOPATH}/bin/promhouse /tmp/profile382238388/mem.pprof > profilegraph.pdf
 ```
 
+## Manually testing load
+If you want to see how Prometheus and PromHouse behave under load,
+1. Start up the test environment in a terminal. To do that, run:
+```bash
+make up
+```
+This will start all the test environment (grafana, prometheus...) and promhouse.
+2. Generate some load. In another terminal run:
+```bash
+make generate-load
+```
+This will start up a docker container with Avalanch, and will generate metrics (default settings).
+
+### Graph what is going on
+You can go to the Prometheus console to see what is going on, in `http://127.0.0.1:9090/graph`.
+Under graph, you can add serveral graphs and see what is happening
+Useful queries to graph are:
+1. `process_resident_memory_bytes` : to see how much memory each of the components is using. PromHouse and Prometheus will most likely be the highest consumers
+NOTE: you have limits defined in the compose file. They are set to a maximum of 2.5GB for each one. If it is too much or too little, you can modify them.
+2. `scrape_samples_scraped`: to visualize how many samples have been processed.
+3. `prometheus_remote_storage_queue_length`: to see the PromHouse queue size.
+4. `rate(clickhouse_insert_query_total[1m])`: to see the insert rate per minute (how many inserts are sent to clickhouse).
+5. `rate(clickhouse_inserted_rows_total[1m])`: to see the rate of rows inserted in clickhouse.
+6. `prometheus_remote_storage_dropped_samples_total`: to monitor if any samples are dropped.
+
 ## Database Schema
 
 ```sql

--- a/misc/docker-compose-linux.yml
+++ b/misc/docker-compose-linux.yml
@@ -14,6 +14,10 @@ services:
               "--storage.tsdb.retention=5m",
               "--web.console.libraries=/usr/share/prometheus/console_libraries",
               "--web.console.templates=/usr/share/prometheus/consoles"]
+    deploy:
+      resources:
+        limits:
+          memory: 2.5G
 
   node_exporter:
     container_name: node_exporter

--- a/misc/docker-compose-promhouse.yml
+++ b/misc/docker-compose-promhouse.yml
@@ -1,0 +1,24 @@
+---
+version: '3'
+services:
+  promhouse:
+    container_name: promhouse
+    image: golang
+    ports:
+      - 127:0.0.1:7781:7781
+      - 127:0.0.1:7782:7782
+    network_mode: host
+    volumes:
+      - ./promhouse_bin:/promhouse_bin
+    entrypoint: "/promhouse_bin"
+    command: ["--log.level=info"]
+    depends_on:
+      - grafana
+      - prometheus
+      - clickhouse_exporter
+      - clickhouse
+      - node_exporter
+    deploy:
+      resources:
+        limits:
+          memory: 2.5G

--- a/misc/prometheus/linux.yml
+++ b/misc/prometheus/linux.yml
@@ -34,11 +34,16 @@ scrape_configs:
     static_configs:
       - targets: ['127.0.0.1:9099']
 
+  - job_name: avalanch
+    static_configs:
+      - targets: ['127.0.0.1:9001']
+
+
 remote_read:
   - url: http://127.0.0.1:7781/read
 
 remote_write:
-  - url: http://docker.for.mac.host.internal:7781/write
+  - url: http://127.0.0.1:7781/write
     queue_config:
       capacity: 1000000
       max_shards: 50


### PR DESCRIPTION
Why: we need to be able to assess if the memory usage of Prometheus +
Promhouse is ok. In order to do that we need to generate some load and
graph how it behaves. This commit includes:
1. Updates to makefile to run promhouse as part of the compose up, so we
can add memory limits to it.
2. Make command to run avalanch (generates metrics)
3. Updates to README file to keep document how to generate graphs with
relevant metrics using the Prometheus console