### PR TITLE
TEL-1242: remove local dependencies from load test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,14 @@ up-test-env:	        ## Starts the test environment - no promhouse (Linux)
 up-mac-test-env:        ## Starts the test environment - no promhouse (Mac)
 	docker-compose -f misc/docker-compose-mac.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
 
-up: install		## Starts the test environment - with promhouse (Linux)
+up: build		## Starts the test environment - with promhouse (Linux)
 	rm -f misc/promhouse_bin
-	cp ${GOPATH}/bin/promhouse misc/promhouse_bin
+	cp promhouse misc/promhouse_bin
 	docker-compose -f misc/docker-compose-linux.yml -f misc/docker-compose-promhouse.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
 
-up-mac: install         ## Starts the test environment - with promhouse (Mac)
+up-mac: build         ## Starts the test environment - with promhouse (Mac)
 	rm -f misc/promhouse_bin
-	cp ${GOPATH}/bin/promhouse misc/promhouse_bin
+	cp promhouse misc/promhouse_bin
 	docker-compose -f misc/docker-compose-mac.yml -f misc/docker-compose-promhouse.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
 
 generate-load:          ## generates metrics in a running test environment with avalanch

--- a/README.md
+++ b/README.md
@@ -93,10 +93,14 @@ go tool pprof --pdf ${GOPATH}/bin/promhouse /tmp/profile382238388/mem.pprof > pr
 ```
 
 ## Manually testing load
-If you want to see how Prometheus and PromHouse behave under load,
-1. Start up the test environment in a terminal. To do that, run:
+If you want to see how Prometheus and PromHouse behave under load. You don't have any dependencies (not go or anything else) apart from docker and compose.
+1. Build the binaries and start up up the test environment in a terminal. To do that, run:
 ```bash
 make up
+```
+or if you are in mac:
+```bash
+make up-mac
 ```
 This will start all the test environment (grafana, prometheus...) and promhouse.
 2. Generate some load. In another terminal run:

--- a/misc/local/entrypoint.sh
+++ b/misc/local/entrypoint.sh
@@ -12,10 +12,6 @@ make protos
 echo "Build"
 make install
 
-echo "Test"
-
-make test
-
 echo "Copying binaries"
 cp /go/bin/prom* /go/src/github.com/hmrc/Promhouse/
 


### PR DESCRIPTION
Why: in order to run the load test, the local environment had to be
configured with go and prototools. We made it use containers so anybody
can run it