### PR TITLE
Fix promhouse container to run in docker for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ up: build		## Starts the test environment - with promhouse (Linux)
 up-mac: build         ## Starts the test environment - with promhouse (Mac)
 	rm -f misc/promhouse_bin
 	cp promhouse misc/promhouse_bin
-	docker-compose -f misc/docker-compose-mac.yml -f misc/docker-compose-promhouse.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
+	docker-compose -f misc/docker-compose-mac.yml -f misc/docker-compose-promhouse-mac.yml -p promhouse up --force-recreate --abort-on-container-exit --renew-anon-volumes --remove-orphans
 
 generate-load:          ## generates metrics in a running test environment with avalanch
 	docker run --net=host quay.io/freshtracks.io/avalanche

--- a/misc/docker-compose-promhouse-mac.yml
+++ b/misc/docker-compose-promhouse-mac.yml
@@ -1,0 +1,19 @@
+---
+version: '3'
+services:
+  promhouse:
+    container_name: promhouse
+    image: golang
+    ports:
+      - 127:0.0.1:7781:7781
+      - 127:0.0.1:7782:7782
+    volumes:
+      - ./promhouse_bin:/promhouse_bin
+    entrypoint: "/promhouse_bin"
+    command: ["--log.level=info"]
+    depends_on:
+      - grafana
+      - prometheus
+      - clickhouse_exporter
+      - clickhouse
+      - node_exporter


### PR DESCRIPTION
Why: there is no net=host in docker for mac as it runs in a VM.
The limits are also not needed as it runs a VM and its resources are
limited